### PR TITLE
v1.3.1: Add 'Done.' message to simulated submission

### DIFF
--- a/learn-submit.gemspec
+++ b/learn-submit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "netrc"
+  spec.add_runtime_dependency "netrc", '~> 0'
   spec.add_runtime_dependency "git", "~> 1.2"
-  spec.add_runtime_dependency "learn-web", ">= 1.5.0"
+  spec.add_runtime_dependency "learn-web", "~> 1.5", ">= 1.5.0"
 end

--- a/lib/learn_submit/submission.rb
+++ b/lib/learn_submit/submission.rb
@@ -78,6 +78,7 @@ module LearnSubmit
           )
         end
 
+        puts 'Done.'
         after_ide_submission(repo_name)
       rescue Timeout::Error
         if retries > 0
@@ -133,7 +134,7 @@ module LearnSubmit
 
         case pr_response.status
         when 200
-          puts "Done."
+          puts 'Done.'
           after_ide_submission(repo_name)
           File.write(file_path, 'Done.')
           exit

--- a/lib/learn_submit/version.rb
+++ b/lib/learn_submit/version.rb
@@ -1,3 +1,3 @@
 module LearnSubmit
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Aligns output from the simulated submission with that of a real submission. The simulated submission is for students who have started the course but not yet created a GH account yet. They're pretty dependent on visual cues, e.g., https://github.com/learn-co-curriculum/welcome-to-learn-5/issues/66, and it's likely that all of our screenshots were taken by users with a GH account (so the `Done.` message is present).

I put the `Done.` just above the `after_ide_submission(repo_name)` call, which is the same order of ops as a real submission.